### PR TITLE
Fix ScoreCard#winner calculation

### DIFF
--- a/lib/roshambo/score_card.rb
+++ b/lib/roshambo/score_card.rb
@@ -26,7 +26,7 @@ module Roshambo
     def winner
       if @card[0] > @card[1]
         competitor1
-      elsif @card[1] > @card[2]
+      elsif @card[1] > @card[0]
         competitor2
       end
     end


### PR DESCRIPTION
@tcollier

The ScoreCard was rewarding competitor 2 the Match when they had more wins than there were draws, not more wins than competitor 1. Now things run evenly:

```
$ bin/check_fairness 10000
### Running competitors in order (Devil 0, Devil 1)
Devil 0  |  4512  |  45.1%
Devil 1  |  4502  |  45.0%
draw     |  986   |  9.9%

### Reversing competitor order (Devil 1, Devil 0)
Devil 0  |  4513  |  45.1%
Devil 1  |  4515  |  45.2%
draw     |  972   |  9.7%
```
